### PR TITLE
fix: weather.noaa.gov has moved

### DIFF
--- a/aviationdata/receiver/metarreceiver.py
+++ b/aviationdata/receiver/metarreceiver.py
@@ -1,7 +1,7 @@
 from . import Receiver
 
 class MetarReceiver(Receiver):
-    _url = 'http://weather.noaa.gov/pub/data/observations/metar/stations/%s.TXT'
+    _url = 'http://tgftp.nws.noaa.gov/pub/data/observations/metar/stations/%s.TXT'
 
     def receive(self):
         x = super(MetarReceiver, self).receive()

--- a/aviationdata/receiver/tafreceiver.py
+++ b/aviationdata/receiver/tafreceiver.py
@@ -2,7 +2,7 @@ from . import Receiver
 
 
 class TafReceiver(Receiver):
-    _url = 'http://weather.noaa.gov/pub/data/forecasts/taf/stations/%s.TXT'
+    _url = 'http://tgftp.nws.noaa.gov/pub/data/forecasts/taf/stations/%s.TXT'
 
     def receive(self):
         x = super(TafReceiver, self).receive()


### PR DESCRIPTION
Everything HTTPish on weather.noaa.gov gives a notice to use `tgftp.nws.noaa.gov` instead, but they do not redirect…